### PR TITLE
[WIP] fixes and npm testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 jwacs
+*.fasl
+*~

--- a/explicitize-transformation.lisp
+++ b/explicitize-transformation.lisp
@@ -236,9 +236,12 @@
         (unnested-explicitize (if-statement-then-statement elm))
       (multiple-value-bind (else-proxy else-prereqs)
           (unnested-explicitize (if-statement-else-statement elm))
-        (values (make-if-statement :condition cond-proxy
-                                   :then-statement (single-statement then-prereqs then-proxy)
-                                   :else-statement (single-statement else-prereqs else-proxy)
+        (values (make-if-statement :label (source-element-label elm)
+                                   :condition cond-proxy
+                                   :then-statement (transfer-label (single-statement then-prereqs then-proxy)
+                                                                   (if-statement-then-statement elm))
+                                   :else-statement (transfer-label (single-statement else-prereqs else-proxy)
+                                                                   (if-statement-else-statement elm))
                                    :start (source-element-start elm)
                                    :end (source-element-end elm))
                 cond-prereqs)))))

--- a/jwacs-tests.asd
+++ b/jwacs-tests.asd
@@ -3,13 +3,15 @@
 ;;; Defines an asdf system containing unit tests for jwacs.
 
 (defpackage :jwacs-tests-system
-  (:use :cl :asdf :uiop)
+  (:use :cl :asdf :uiop :trivial-shell)
   (:nicknames :jw-tests-system))
 (in-package :jwacs-tests-system)
 
 ;;;; ======= Custom ASDF file types ================================================================
 (defclass jwacs-file (static-file)
   ((type :initform "jw")))
+(defclass js-file (static-file)
+  ((type :initform "js")))
 
 ;;;; ======= System definition =====================================================================
 (defsystem "jwacs-tests"
@@ -40,6 +42,8 @@
                (:file "test-loop-transformation")
                (:file "test-trampoline-transformation")
                (:file "test-runtime-transformation")
-               (:jwacs-file "lang-tests"))))
+               (:file "test-js-eval")
+               (:jwacs-file "lang-tests")
+               (:js-file "rt-test-harness"))))
     :depends-on ("jwacs")
     :perform (test-op (o c) (symbol-call :jw-tests :do-tests)))

--- a/lex-javascript.lisp
+++ b/lex-javascript.lisp
@@ -222,7 +222,12 @@
                                   (:greedy-repetition 0 1
                                     (:sequence (:alternation #\e #\E)
                                                (:greedy-repetition 0 1 (:alternation #\+ #\-))
-                                               (:greedy-repetition 1 nil :digit-class)))))))
+                                               (:greedy-repetition 1 nil :digit-class))))
+                                (:sequence
+                                  (:greedy-repetition 1 nil :digit-class)
+                                  (:alternation #\e #\E)
+                                  (:greedy-repetition 0 1 (:alternation #\+ #\-))
+                                  (:greedy-repetition 1 nil :digit-class)))))
 
   "Regular expression for recognizing floating-point literals")
 

--- a/lex-javascript.lisp
+++ b/lex-javascript.lisp
@@ -364,9 +364,17 @@
   ((cursor :initform 0 :accessor cursor)
    (text :initarg :text :reader text)
    (unget-stack :initform nil :accessor unget-stack)
-   (encountered-line-terminator :initform nil :accessor encountered-line-terminator))
+   (encountered-line-terminator :initform nil :accessor encountered-line-terminator)
+   (regexp-possible :initform nil :accessor regexp-possible))
   (:documentation
    "Represents the current state of a lexing operation"))
+
+(defun regexp-possible-p (terminal)
+  (case terminal
+    ((:identifier :null :true :false :this :right-bracket :right-paren
+                  :minus2 :plus2 :number :string-literal)
+     nil)
+    (otherwise t)))
 
 (defun next-token (lexer)
   "Returns a token structure containing the next token in the lexing operation
@@ -474,7 +482,7 @@
    character on entry; on exit points to the first character after the consumed token.
    Returns a token structure.  The token's terminal will be NIL on end of input"
   (with-slots (text cursor) lexer
-    (re-cond (text :start cursor)
+    (let* ((token (re-cond (text :start cursor)
        ("^$"
         (make-token :terminal nil :start (length text) :end (length text)))
        (floating-re
@@ -492,10 +500,16 @@
                              :identifier)))
           (make-token :terminal terminal :start %s :end %e :value text)))
        (regexp-re
-        (set-cursor lexer %e)
-        (make-token :terminal :re-literal :start %s :end %e
-                    :value (cons (unescape-regexp (subseq text (aref %sub-s 0) (aref %sub-e 0)))
-                                 (subseq text (aref %sub-s 1) (aref %sub-e 1)))))
+        (if (regexp-possible lexer)
+            (progn
+              (set-cursor lexer %e)
+              (make-token :terminal :re-literal :start %s :end %e
+                          :value (cons (unescape-regexp (subseq text (aref %sub-s 0) (aref %sub-e 0)))
+                                       (subseq text (aref %sub-s 1) (aref %sub-e 1)))))
+            (progn
+              (set-cursor lexer (+ %s 1))
+              (make-token :terminal :slash :start %s :end (+ %s 1)
+                          :value "/"))))
        (string-re
         (set-cursor lexer %e)
         (make-token :terminal :string-literal :start %s :end %e
@@ -512,6 +526,9 @@
         (error "unrecognized token: '~A'" (subseq text %s %e)))
        (t
         (error "coding error - we should never get here")))))
+      (setf (regexp-possible lexer)
+            (regexp-possible-p (token-terminal token)))
+      token)))
 
 ;; TODO Tab handling
 (defun position-to-line/column (text index)

--- a/parse-javascript.lisp
+++ b/parse-javascript.lisp
@@ -73,6 +73,7 @@
   ((property-name :identifier) (make-string-literal :value $$1 :start $s :end $e))
   ((property-name :string-literal) (make-string-literal :value $$1 :start $s :end $e))
   ((property-name :number) (make-numeric-literal :value $$1 :start $s :end $e))
+  ((property-name permissible-property) (make-string-literal :value $$1 :start $s :end $e))
 
   ;; Pg 55
   ((member-expression primary-expression) $1)
@@ -83,6 +84,38 @@
                                                                                                             :start (token-start $3)
                                                                                                             :end (token-end $3))
                                                                                 :start $s :end $e))
+  ((member-expression member-expression :dot permissible-property) (make-property-access :target $1
+                                                                                         :field (make-string-literal :value $$3
+                                                                                                                     :start (token-start $3)
+                                                                                                                     :end (token-end $3))
+                                                                                         :start $s :end $e))
+
+  ((permissible-property permissible-property :no-line-terminator) $1)
+  
+  ;; (map 'list (lambda (s) `((permissible-property ,s) $1)) *keyword-symbols*)
+  ((PERMISSIBLE-PROPERTY :WITH) $1)       ((PERMISSIBLE-PROPERTY :WHILE) $1)
+  ((PERMISSIBLE-PROPERTY :VOID) $1)       ((PERMISSIBLE-PROPERTY :VAR) $1)
+  ((PERMISSIBLE-PROPERTY :TYPEOF) $1)     ((PERMISSIBLE-PROPERTY :TRY) $1)
+  ((PERMISSIBLE-PROPERTY :TRUE) $1)       ((PERMISSIBLE-PROPERTY :THROW) $1)
+  ((PERMISSIBLE-PROPERTY :THIS) $1)       ((PERMISSIBLE-PROPERTY :SWITCH) $1)
+  ((PERMISSIBLE-PROPERTY :RETURN) $1)     
+  ((PERMISSIBLE-PROPERTY :NULL) $1)       ((PERMISSIBLE-PROPERTY :NEW) $1)
+  ((PERMISSIBLE-PROPERTY :INSTANCEOF) $1) ((PERMISSIBLE-PROPERTY :IN) $1)
+  ((PERMISSIBLE-PROPERTY :IMPORT) $1)     ((PERMISSIBLE-PROPERTY :IF) $1)
+  ((PERMISSIBLE-PROPERTY :FUNCTION) $1)   ((PERMISSIBLE-PROPERTY :FOR) $1)
+  ((PERMISSIBLE-PROPERTY :FINALLY) $1)    ((PERMISSIBLE-PROPERTY :FALSE) $1)
+  ((PERMISSIBLE-PROPERTY :ENUM) $1)       ((PERMISSIBLE-PROPERTY :ELSE) $1)
+  ((PERMISSIBLE-PROPERTY :DO) $1)         ((PERMISSIBLE-PROPERTY :DELETE) $1)
+  ((PERMISSIBLE-PROPERTY :DEFAULT) $1)    ((PERMISSIBLE-PROPERTY :DEBUGGER) $1)
+  ((PERMISSIBLE-PROPERTY :CONTINUE) $1)   ((PERMISSIBLE-PROPERTY :CONST) $1)
+  ((PERMISSIBLE-PROPERTY :CATCH) $1)      ((PERMISSIBLE-PROPERTY :CASE) $1)
+  ((PERMISSIBLE-PROPERTY :BREAK) $1)
+
+  ;; also permit jwacs keywords as object properties
+  ((PERMISSIBLE-PROPERTY :RESUME) $1)
+  ((PERMISSIBLE-PROPERTY :FUNCTION_CONTINUATION) $1)
+
+  
   ((member-expression :new member-expression arguments) (make-new-expr :constructor $2 :args $3 :start $s :end $e))
 
   ((member-expression-no-lbf primary-expression-no-lbf) $1)
@@ -92,6 +125,11 @@
                                                                                                                           :start (token-start $3)
                                                                                                                           :end (token-end $3))
                                                                                               :start $s :end $e))
+  ((member-expression-no-lbf member-expression-no-lbf :dot permissible-property) (make-property-access :target $1
+                                                                                                       :field (make-string-literal :value $$3
+                                                                                                                                   :start (token-start $3)
+                                                                                                                                   :end (token-end $3))
+                                                                                                       :start $s :end $e))
   ((member-expression-no-lbf :new member-expression arguments) (make-new-expr :constructor $2 :args $3 :start $s :end $e))
 
   ((new-expression member-expression) $1)

--- a/parse-javascript.lisp
+++ b/parse-javascript.lisp
@@ -669,18 +669,6 @@
              (handle-yacc-error (err)
                (cond
 
-                 ;; Irritating regular-expression-literal vs. division ambiguity case.
-                 ;; If we encounter an unexpected RE literal, try interpreting it as a
-                 ;; division operator instead.  We do that by rewinding the lexer to
-                 ;; just before the RE literal and instructing it to read the slash as
-                 ;; just a slash.  We then instruct the parser to throw away the RE
-                 ;; literal and continue parsing.
-                 ((and (eq :re-literal (yacc:yacc-parse-error-terminal err))
-                       (find :slash (yacc:yacc-parse-error-expected-terminals err)))
-                  (set-cursor lexer (token-start (yacc:yacc-parse-error-value err)))
-                  (coerce-token lexer :slash)
-                  (invoke-restart 'yacc:skip-terminal))
-                 
                  ;; Don't try to perform semicolon insertion unless inserted-semicolons are permitted
                  ((null (find :inserted-semicolon (yacc:yacc-parse-error-expected-terminals err)))
                   (resignal err))

--- a/parse-javascript.lisp
+++ b/parse-javascript.lisp
@@ -544,6 +544,7 @@
   ((continue-statement :continue :line-terminator) (make-continue-statement :start $s :end $e))
 
   ((break-statement :break :no-line-terminator :identifier insertable-semicolon) (make-break-statement :target-label $$3 :start $s :end $e))
+  ((break-statement :break :no-line-terminator :inserted-semicolon) (make-break-statement :start $s :end $e))
   ((break-statement :break :no-line-terminator :semicolon) (make-break-statement :start $s :end $e))
   ((break-statement :break :line-terminator) (make-break-statement :start $s :end $e))
 

--- a/tests/package.lisp
+++ b/tests/package.lisp
@@ -154,5 +154,16 @@
                 value-node
                 location-node
                 explicitly-terminated-p
-                ))
+
+                ;; compilation
+                module
+                make-module
+                with-module-output
+                pipeline-compile
+                *compiler-pipeline*
+                emit-elms
+                get-module-text
+                generate-runtime
+                *runtime-text*
+                *debug-runtime-text*))
                 

--- a/tests/rt-test-harness.js
+++ b/tests/rt-test-harness.js
@@ -1,0 +1,134 @@
+var deepDiff = require('deep-diff');
+
+//console.log("Hello From Node!")
+//console.log("Args are: ", process.argv);
+
+//console.log("Catting input lines ... ")
+//var fs = require('fs');
+//var js = fs.readFileSync(0).toString();
+// console.log("Compiling test js to function(dep0, dep1, dep2, dep3, dep4, dep5)", js);
+// var test_fn = new Function([
+//     "dep0", "dep1", "dep2", "dep3", "dep4", "dep5"
+// ], js);
+
+function pprint(data) {
+    return JSON.stringify(data, null, 2);
+}
+
+function simple_effect(label, ret_fn) {
+    var ret = function (trace_array) {
+        return function () {
+            var args = Array.prototype.slice.call(arguments);
+            args.unshift(label);
+            trace_array.push(args);
+            return ret_fn ? ret_fn.apply(null, arguments) : args;
+        }
+    };
+    ret.label = label;
+    ret.effect_id = "simple_tracing";
+    return ret;
+}
+
+function wrapEffects(fn_unwrapped, effects) {
+    return (function (data, trace_array, on_finish) {
+        var effect_instances = effects.map(function(eff) {
+            return eff(trace_array);
+        });
+        effect_instances.unshift(on_finish)
+        var fn_with_effects = fn_unwrapped.apply(null, effect_instances);
+        //console.log("APPLYING EFFECTS", fn_unwrapped, effect_instances, fn_with_effects)
+        fn_with_effects.apply(null, data);
+    });
+}
+
+function doRun(fn, data, on_finish) {
+    var trace = [];
+    return fn(data, trace, function (ret) {
+        on_finish({result: ret,
+                   effect_trace: trace});
+    });
+}
+
+function testHarness(fn_original, fn_transformed, effects_original, effects_transformed, on_finish) {
+    var orig = wrapEffects(fn_original, effects_original);
+    var tran = wrapEffects(fn_transformed, effects_transformed);
+    return (function test() {
+        var data = Array.prototype.slice.call(arguments);
+        // console.log("STARTING RUN", data);
+        doRun(orig, data, function(orig_res) {
+            // console.log("FINISHED ORIG", orig_res);
+            doRun(tran, data, function(tran_res) {
+                // console.log("FINISHED TRAN", tran_res);
+                on_finish({
+                    input_data: data,
+                    original_result: orig_res,
+                    transformed_result: tran_res
+                });
+            });
+            
+        });
+    });
+}
+
+var default_effects = [
+    simple_effect("f"),
+    simple_effect("g"),
+    simple_effect("h"),
+    simple_effect("i"),
+    simple_effect("j"),
+    simple_effect("k"),
+    simple_effect("l"),
+    simple_effect("m")
+];
+
+var n_effects = ["f","g","h","i","j","k","l","m"];
+function runTests ({ fn_original, fn_transformed, effect_factory_original, effect_factory_transformed, data }) {
+    var harny = testHarness(
+        fn_original,
+        fn_transformed,
+        n_effects.map(effect_factory_original),
+        n_effects.map(effect_factory_transformed),
+        function(result){
+            var rdiff = deepDiff.diff(result.original_result.result, result.transformed_result.result) || [];
+            var etdiff = deepDiff.diff(result.original_result.effect_trace, result.transformed_result.effect_trace) || [];
+            if (rdiff.length > 0) {
+                console.log("ERROR", "result differs", pprint({
+                    original_result: result.original_result.result,
+                    transformed_result: result.transformed_result.result,
+                    input_data: result.input_data
+                }));
+            } else if (etdiff.length > 0) {
+                console.log("WARNING", "effect trace differs", pprint({
+                    input_data: result.input_data,
+                    result: result.original_result.result
+                }));
+            } else {
+                console.log ("INFO", JSON.stringify(result.input_data),
+                             result.original_result.result,
+                             rdiff, " ... OK");
+                var et = [];
+                // for(var i=0;i<100;i++){
+                //     et.push(result.original_result.effect_trace[i]);
+                // }
+                // console.log ("INFO", "100 elements of effect trace", pprint(et));
+            }
+            if (etdiff.length > 0) {
+                var et = [];
+                for(var i=0;i<100;i++){
+                    et.push([result.original_result.effect_trace[i], result.transformed_result.effect_trace[i]]);
+                }
+                console.log ("INFO", "100 elements of effect trace", pprint(et));
+            }
+        }
+    );
+    for (let args of data) {
+        harny.apply(null, args);
+    }
+}
+
+module.exports = {
+    testHarness: testHarness,
+    default_effects: default_effects,
+    pprint: pprint,
+    runTests: runTests
+};

--- a/tests/test-js-eval.lisp
+++ b/tests/test-js-eval.lisp
@@ -1,0 +1,145 @@
+(in-package :jwacs-tests)
+
+(defun node (&rest args)
+  (trivial-shell:shell-command
+   (format nil "node ~A"
+           (asdf:component-pathname
+            (asdf:find-component (asdf:find-component (asdf:find-system :jwacs-tests)
+                                                      "tests")
+                                 "rt-test-harness")))
+   :input "Here is some input!"))
+
+(defun emit-js (ast)
+  (let ((module (make-module :type 'js :compressed-p nil
+                             :inline-stream (make-string-output-stream))))
+    (with-module-output (out module)
+      (emit-elms ast out :pretty-output t)
+      (get-module-text module))))
+
+(defun parse-expr (s)
+  (car (parse s #+-(concatenate 'string "(" s ")"))))
+
+(defun write-test (target-dir name effect-factory transform-effect-factory source data)
+  (let ((out-path (make-pathname
+                   :directory target-dir
+                   :name name
+                   :type "js")))
+    (ensure-directories-exist out-path)
+    (let ((module (make-module :path out-path :type 'js :compressed-p nil))
+          (tran-source (pipeline-compile source *compiler-pipeline*))
+          (tran-effect-factory (pipeline-compile transform-effect-factory *compiler-pipeline*)))
+      (with-module-output (out module)
+        (format out "~A" *runtime-text*)
+        (emit-elms
+         (make-fn-call :fn (parse-expr #+-"require(\"./rt-test-harness\").run_tests"
+                                       (concatenate
+                                        'string "require(\""
+                                        (namestring
+                                         (asdf:component-pathname
+                                          (asdf:find-component (asdf:find-component (asdf:find-system :jwacs-tests)
+                                                                                    "tests")
+                                                               "rt-test-harness")))
+                                        "\").runTests"))
+                       :args (list (make-object-literal
+                                    :properties
+                                    `((#s(string-literal :value "fn_original") .
+                                         ,source)
+                                      (#s(string-literal :value "fn_transformed") .
+                                         ,tran-source)
+                                      (#s(string-literal :value "effect_factory_original") .
+                                         ,effect-factory)
+                                      (#s(string-literal :value "effect_factory_transformed") .
+                                         ,tran-effect-factory)
+                                      (#s(string-literal :value "data") .
+                                         ,data)))))
+         out :pretty-output t)))))
+
+'(comment
+
+  *runtime-text*
+
+  (defvar number-gen-async (parse-expr "(function async_number_gen(n) {
+    var label = \"number-\" + n;
+    var rand = require('random-seed').create(label);
+    var ret = function (trace_array) {
+        return function () {
+            var args = Array.prototype.slice.call(arguments);
+            var ret = rand.floatBetween(-5,5);
+            Array.prototype.unshift.call(args, ret);
+            Array.prototype.unshift.call(args, label);
+            Array.prototype.push.call(trace_array, args);
+            var k = function_continuation;
+            setTimeout(function(){
+              resume k <- ret
+            }, 1);
+            suspend;
+        }
+    };
+    ret.label = label;
+    ret.effect_id = \"number-gen\";
+    return ret;
+})"))
+
+  (defvar number-gen
+    (parse-expr "(function number_gen(n) {
+    var label = \"number-\" + n;
+    var rand = require('random-seed').create(label);
+    var ret = function (trace_array) {
+        return function () {
+            var args = Array.prototype.slice.call(arguments);
+            var ret = rand.floatBetween(-5,5);
+            Array.prototype.unshift.call(args, ret);
+            Array.prototype.unshift.call(args, label);
+            Array.prototype.push.call(trace_array, args);
+            return ret;
+        }
+    };
+    ret.label = label;
+    ret.effect_id = \"number-gen\";
+    return ret;
+})"))
+  
+  (write-test "/tmp/foo" "simple"
+   number-gen number-gen
+   (parse-expr "(function (on_finish, f,g,h){
+  return function(a,b,c) {
+    var i = 10;
+    while(i>0) {
+    i--;
+    if(a < 0.5) {
+      c = c + h(a,b,c)*0.1 + f(a,b,c)*0.1;
+    } else {
+      c = c + g(a,b,c)*0.1 + h(a,b,c)*0.1;
+    }
+    if(b < 0.5) {
+      a = a + f(a,b,c)*0.1 + h(a,b,c)*0.1;
+    } else {
+      b = b + h(a,b,c)*0.1 + g(a,b,c)*0.1;
+    }
+    if(c < 0.5) {
+      b = b + g(a,b,c)*0.1 + f(a,b,c)*0.1;
+    } else {
+      a = a + f(a,b,c)*0.1 + g(a,b,c)*0.1;
+    }
+    }
+    on_finish([a,b,c]);
+  }
+})")
+   (parse-expr "[[0.2, 0.7, 0.51],[0.2, 0.7, 0.51],[0.4, 0.6, 0.49],[0.8, 0.45, 0.21]]"))
+
+
+  (pipeline-compile
+   (car (parse "function X(a){return a();}"))
+   *compiler-pipeline*)
+  
+
+  '(let ((harness (asdf:component-pathname
+                   (asdf:find-component (asdf:find-component (asdf:find-system :jwacs-tests) "tests") "rt-test-harness"))))
+    (defun compile-node-test (js-fn)
+      ))
+
+  '(cl:ensure-directories-exist
+    (uiop/pathname:merge-pathnames*
+     (uiop:temporary-directory)
+     (random 10000))
+    ))


### PR DESCRIPTION
Hi, I've stumbled over your project, when looking for .. well, a CPS transformer for javascript, that does what it should. It's pretty impressive, congrats!

I tried to apply it to some JS, I've got laying around and quickly found some lexer and parser bugs:
- 'integer' with exponent
- an incomplete regex workaround, that I replaced with the approach found here: https://github.com/antlr/grammars-v4/blob/3b25fdc6dc6a2ea74c000406e2439fdc1d2f64e7/ecmascript/JavaScript/ECMAScript.g4#L108
- semicolon insertion for break as last block element

Each of the above fixes is rather simple, but WIP in the sense, that the parser fixes should probably be fixed in the descriptor file, right? I hope you can help there.

After those fixes, that made my 2.4M minified JS file parse (correctly?), I ran into two missing CPS transformations: breaks in labelled statement-blocks and (obviously) finally.

I implemented labelled blocks, but before trying finally (ha), I'd like to have (possibly generative) side-by-side testing in nodejs. The initial thing looks promising (see last commit), but I'll probably have to leave it for some time and come back later ..

I'll comment some more on the specific commits, feel free to leave feedback and request changes ..